### PR TITLE
ci: manage ngx-build-plus for all Angular versions

### DIFF
--- a/.github/actions/package-version/action.yml
+++ b/.github/actions/package-version/action.yml
@@ -13,5 +13,5 @@ runs:
   using: "composite"
 
   steps:
-    - run: node ${{ github.action_path }}/package-version.mjs ${{ inputs.name }} ${{ inputs.version }}
+    - run: node ${{ github.action_path }}/package-version.mjs "${{ inputs.name }}" "${{ inputs.version }}"
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
       matrix:
         angular-version:
           - 9.0.x
-          # - 9.1.x
+          - 9.1.x
           - 10.0.x
           - 10.1.x
-          # - 10.2.x
+          - 10.2.x
           - 11.0.x
-          # - 11.1.x
-          # - 11.2.x
+          - 11.1.x
+          - 11.2.x
 
     steps:
       # Source code
@@ -37,7 +37,7 @@ jobs:
       - uses: ./.github/actions/package-version
         with:
           name: "ngx-build-plus"
-          version: ${{ matrix.angular-version }}
+          version: <=${{ matrix.angular-version }}
 
       - run: npm install --global pnpm
       - run: pnpm install --frozen-lockfile false --verify-store-integrity false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: ./.github/actions/package-version
         with:
           name: "ngx-build-plus"
-          version: <=${{ matrix.angular-version }}
+          version: "<=${{ matrix.angular-version }}"
 
       - run: npm install --global pnpm
       - run: pnpm install --frozen-lockfile false --verify-store-integrity false


### PR DESCRIPTION
`ngx-build-plus` does not have versions matching all Angular versions. Rather than introducing more matrix parameters or step conditions, we accept for example `<=11.2.x` which currently resolves to `11.0.x`.